### PR TITLE
Build and deploy project with pnpm install failure

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm install -g pnpm
+        - pnpm install
+    build:
+      commands:
+        - pnpm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+      - .next/cache/**/*

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "guerci",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@8.15.6",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Configure AWS Amplify to use pnpm for builds by adding `amplify.yml` and specifying `packageManager` in `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-de141a23-c900-4c1a-8b43-854ef54c89a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de141a23-c900-4c1a-8b43-854ef54c89a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

